### PR TITLE
Ember upgrade 4.0 related changes 

### DIFF
--- a/addon/components/spark-line.js
+++ b/addon/components/spark-line.js
@@ -1,9 +1,10 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import layout from '../templates/components/spark-line';
+import { addObserver } from '@ember/object/observers';
+import { on } from '@ember/object/evented';
+import { isPresent } from '@ember/utils';
 
-const { on,isPresent } = Ember;
-
-export default Ember.Component.extend({
+export default Component.extend({
     layout: layout,
     tagName: 'div',
 
@@ -12,6 +13,10 @@ export default Ember.Component.extend({
     didInsertElement() {
         this.drawSparkline();
     },
+    init() {
+        this._super(...arguments);
+        addObserver(this, 'data.length','data.[]', this.listenDataChanges);
+    },
 
     drawSparkline() {
         let sparkline,
@@ -19,12 +24,12 @@ export default Ember.Component.extend({
         options = this.get('options') || {},
         data = this.get('data');
 
-        sparkline = this.$().sparkline(data, options);
+        sparkline = $(this.element).sparkline(data, options);
 
-        this.$().bind('sparklineClick', function(ev){
+        $(this.element).on('sparklineClick', function(ev){
             _this.set('sparklineClickedElement', ev.sparklines[0]);
         });
-        this.$().bind('sparklineRegionChange', function(ev){
+        $(this.element).on('sparklineRegionChange', function(ev){
             _this.set('sparklineRegionChange', ev.sparklines[0]);
         });
 
@@ -52,11 +57,9 @@ export default Ember.Component.extend({
             this.sparklineHoverOut();
         }
     },
-
-    listenDataChanges: function () {
+    listenDataChanges() {
         this.drawSparkline();
-    }.observes('data.length','data.[]'),
-
+    },
     destroySparkline: on('willDestroyElement', function() {
         this.destroy();
     }),

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.10",
-    "ember-cli-htmlbars": "~5.7.2",
+    "ember-cli-htmlbars": "^6.0.1",
     "jquery.sparkline": "git+https://github.com/kumkanillam/jquery.sparkline.git"
   },
   "devDependencies": {
@@ -33,8 +33,7 @@
     "ember-cli": "~3.28.5",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
-    "ember-cli-htmlbars": "~5.3.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.4.0",
+    "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-shims": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.10",
-    "ember-cli-htmlbars": "^6.0.1",
+    "ember-cli-htmlbars": "~5.7.2",
     "jquery.sparkline": "git+https://github.com/kumkanillam/jquery.sparkline.git"
   },
   "devDependencies": {
@@ -33,7 +33,7 @@
     "ember-cli": "~3.28.5",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
-    "ember-cli-htmlbars": "^6.0.1",
+    "ember-cli-htmlbars": "~5.3.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-shims": "^1.1.0",


### PR DESCRIPTION
Removed the Ember global usage 
Observes replaced with addObserver
this.$() changed to $(this.element)
Removed the ember-cli-htmlbars-inline-precompile addon as it was deprecated and they included in the ember-cli-htmlbars itself